### PR TITLE
Add OrniscientFilterInterceptor to config automatically

### DIFF
--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/Derivco.Orniscient.Proxy.nuspec
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/Derivco.Orniscient.Proxy.nuspec
@@ -1,12 +1,16 @@
 ﻿<?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <metadata>
-        <id>Derivco.Orniscient.Proxy</id>
-        <version>1.0</version>
-        <authors>Derivco Ipswich</authors>
-        <owners>Derivco Ipswich</owners>
-        <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Provides monitoring and visualisation support for an Orleans cluster.</description>
-        <tags>Orleans Monitoring Visualisation</tags>
-    </metadata>
+  <metadata>
+    <id>Derivco.Orniscient.Proxy</id>
+    <version>1.0.0-beta</version>
+    <authors>Derivco Ipswich</authors>
+    <owners>Derivco Ipswich</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Provides monitoring and visualisation support for an Orleans cluster.</description>
+    <tags>Orleans Monitoring Visualisation</tags>
+  </metadata>
+  <files>
+    <file src="OrleansConfiguration.xml.install.xdt" target="content\OrleansConfiguration.xml.install.xdt" />
+    <file src="OrleansConfiguration.xml.uninstall.xdt" target="content\OrleansConfiguration.xml.uninstall.xdt" />
+  </files>
 </package>

--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.install.xdt
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.install.xdt
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<OrleansConfiguration xmlns="urn:orleans" xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+	<Globals xdt:Transform="InsertIfMissing">
+    <BootstrapProviders xdt:Transform="InsertIfMissing">
+      <Provider Type="Derivco.Orniscient.Proxy.BootstrapProviders.OrniscientFilterInterceptor" Name="OrniscientFilterInterceptor" xdt:Locator="Match(Name)" xdt:Transform="InsertIfMissing" />
+    </BootstrapProviders>
+  </Globals>
+</OrleansConfiguration>

--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.uninstall.xdt
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.uninstall.xdt
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<OrleansConfiguration xmlns="urn:orleans" xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <Globals>
+    <BootstrapProviders>
+      <Provider Type="Derivco.Orniscient.Proxy.BootstrapProviders.OrniscientFilterInterceptor" Name="OrniscientFilterInterceptor" xdt:Locator="Match(Name)" xdt:Transform="Remove" />
+    </BootstrapProviders>
+    <BootstrapProviders xdt:Locator="Condition(count(*) = 0)" xdt:Transform="Remove"/>
+  </Globals>
+</OrleansConfiguration>


### PR DESCRIPTION
Added transform files to automatically add the OrniscientFilterInterceptor to the default orleans configuration file. As required, see issue : [#10](https://github.com/DerivcoIpswich/Orniscient/issues/10)

fixes #10
