### PR TITLE
Hotfix/fix startup issue when streams changed

### DIFF
--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.install.xdt
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.install.xdt
@@ -4,5 +4,8 @@
     <BootstrapProviders xdt:Transform="InsertIfMissing">
       <Provider Type="Derivco.Orniscient.Proxy.BootstrapProviders.OrniscientFilterInterceptor" Name="OrniscientFilterInterceptor" xdt:Locator="Match(Name)" xdt:Transform="InsertIfMissing" />
     </BootstrapProviders>
+	 <StreamProviders xdt:Transform="InsertIfMissing">
+		<Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" xdt:Locator="Match(Name)" xdt:Transform="InsertIfMissing" />
+	 </StreamProviders>
   </Globals>
 </OrleansConfiguration>

--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.uninstall.xdt
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/OrleansConfiguration.xml.uninstall.xdt
@@ -5,5 +5,9 @@
       <Provider Type="Derivco.Orniscient.Proxy.BootstrapProviders.OrniscientFilterInterceptor" Name="OrniscientFilterInterceptor" xdt:Locator="Match(Name)" xdt:Transform="Remove" />
     </BootstrapProviders>
     <BootstrapProviders xdt:Locator="Condition(count(*) = 0)" xdt:Transform="Remove"/>
+	<StreamProviders>
+		<Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" xdt:Locator="Match(Name)" xdt:Transform="Remove" />
+	 </StreamProviders>
+	 <StreamProviders xdt:Locator="Condition(count(*) = 0)" xdt:Transform="Remove"/>
   </Globals>
 </OrleansConfiguration>

--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/StreamKeys.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/StreamKeys.cs
@@ -2,7 +2,7 @@
 {
     public class StreamKeys
     {
-        public const string StreamProvider = "SMSProvider";
+        public const string StreamProvider = "OrniscientSMSProvider";
         public const string OrniscientChanges = "OrniscientChanges";
         public const string OrniscientClient = "OrniscientClient";
     }

--- a/Derivco.Orniscient/Derivco.Orniscient.Viewer/DevTestClientConfiguration.xml
+++ b/Derivco.Orniscient/Derivco.Orniscient.Viewer/DevTestClientConfiguration.xml
@@ -10,8 +10,6 @@
     <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s"
                 WriteLogStatisticsToTable="true" />
   <StreamProviders>
-    <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
     <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" />
-    <!--<Provider Type="Orleans.Providers.Streams.Persistent.AzureQueueStreamProvider" Name="AzureQueueProvider" DataConnectionString=""/> -->
   </StreamProviders>
 </ClientConfiguration>

--- a/Derivco.Orniscient/Derivco.Orniscient.Viewer/DevTestClientConfiguration.xml
+++ b/Derivco.Orniscient/Derivco.Orniscient.Viewer/DevTestClientConfiguration.xml
@@ -11,6 +11,7 @@
                 WriteLogStatisticsToTable="true" />
   <StreamProviders>
     <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
+    <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" />
     <!--<Provider Type="Orleans.Providers.Streams.Persistent.AzureQueueStreamProvider" Name="AzureQueueProvider" DataConnectionString=""/> -->
   </StreamProviders>
 </ClientConfiguration>

--- a/Derivco.Orniscient/TestHost/DevTestServerConfiguration.xml
+++ b/Derivco.Orniscient/TestHost/DevTestServerConfiguration.xml
@@ -11,7 +11,7 @@
       <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" DataConnectionString="DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY" />-->
     </StorageProviders>
     <StreamProviders>
-      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider"   PubSubType="ImplicitOnly"/>
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" />
       <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" />
      
     </StreamProviders>

--- a/Derivco.Orniscient/TestHost/DevTestServerConfiguration.xml
+++ b/Derivco.Orniscient/TestHost/DevTestServerConfiguration.xml
@@ -11,8 +11,9 @@
       <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" DataConnectionString="DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY" />-->
     </StorageProviders>
     <StreamProviders>
-      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
-      <!--<Provider Type="Orleans.Providers.Streams.Persistent.AzureQueueStreamProvider" Name="AzureQueueProvider" DataConnectionString=""/> -->
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider"   PubSubType="ImplicitOnly"/>
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" />
+     
     </StreamProviders>
     <LogViewProviders>
       <Provider Type="Orleans.Providers.LogViews.CustomStorageProvider" Name="CustomStorage" />

--- a/Derivco.Orniscient/TestHost2/DevTestClientConfiguration.xml
+++ b/Derivco.Orniscient/TestHost2/DevTestClientConfiguration.xml
@@ -5,10 +5,10 @@
 	For a detailed reference, see "Orleans Configuration Reference.html".
 -->
 <ClientConfiguration xmlns="urn:orleans">
-    <GatewayProvider ProviderType="Config" />
-    <!--<Gateway Address="192.168.57.138" Port="40000" />-->
-    <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s"
-                WriteLogStatisticsToTable="true" />
+  <GatewayProvider ProviderType="Config" />
+  <Gateway Address="localhost" Port="40001" />
+  <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s"
+              WriteLogStatisticsToTable="true" />
   <!--Add to test with cluster-->
   <!--<SystemStore SystemStoreType ="SqlServer"
                  DeploymentId="OrleansTest"

--- a/Derivco.Orniscient/TestHost2/DevTestServerConfiguration.xml
+++ b/Derivco.Orniscient/TestHost2/DevTestServerConfiguration.xml
@@ -12,7 +12,8 @@
     </StorageProviders>
     <StreamProviders>
       <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
-      <!--<Provider Type="Orleans.Providers.Streams.Persistent.AzureQueueStreamProvider" Name="AzureQueueProvider" DataConnectionString=""/> -->
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" />
+      
     </StreamProviders>
     <LogViewProviders>
       <Provider Type="Orleans.Providers.LogViews.CustomStorageProvider" Name="CustomStorage" />

--- a/Derivco.Orniscient/TestHost2/DevTestServerConfiguration.xml
+++ b/Derivco.Orniscient/TestHost2/DevTestServerConfiguration.xml
@@ -11,13 +11,13 @@
       <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" DataConnectionString="DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY" />-->
     </StorageProviders>
     <StreamProviders>
-      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" />
       <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" />
-      
     </StreamProviders>
     <LogViewProviders>
       <Provider Type="Orleans.Providers.LogViews.CustomStorageProvider" Name="CustomStorage" />
     </LogViewProviders>
+    <SeedNode Address="localhost" Port="11111" />
     <BootstrapProviders>
       <Provider Type="Derivco.Orniscient.Proxy.BootstrapProviders.OrniscientFilterInterceptor" Name="OrniscientFilterInterceptor" />
     </BootstrapProviders>


### PR DESCRIPTION
Orniscient needs it own StreamProvider. We had issues on test environment where we changed settings on the stream provider we used, and that broke Orniscient. So changed the code that Orniscient uses a stream provider called OrniscientSMSProvider.

Please add the following to your orleans server config file. 

```  
<StreamProviders>
     <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="OrniscientSMSProvider" />
</StreamProviders>
```

If your configuration file is named OrleansConfiguration.xml the config will be added when installing the nuget package.

