### PR TITLE
Serializing method invocation result to non-complex json

### DIFF
--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/MethodInvocationGrain.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/MethodInvocationGrain.cs
@@ -75,8 +75,8 @@ namespace Derivco.Orniscient.Proxy.Grains
 							method.Parameters.Select(p => GetTypeFromString(p.Type)).ToArray(), null)
 						.Invoke(grain, parameters);
 
-					return await methodInvocation;
-				}
+				    return JsonConvert.SerializeObject(await methodInvocation);
+                }
 			}
 
 			return null;


### PR DESCRIPTION
Method invocation results in an error with complex data types, since orniscient is not aware of said types. Serilaizing the result into json resolves this issue.