### PR TITLE
Updating develop branch with bugfix from master

### DIFF
--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/MethodInvocationGrain.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/MethodInvocationGrain.cs
@@ -75,8 +75,8 @@ namespace Derivco.Orniscient.Proxy.Grains
 							method.Parameters.Select(p => GetTypeFromString(p.Type)).ToArray(), null)
 						.Invoke(grain, parameters);
 
-					return await methodInvocation;
-				}
+				    return JsonConvert.SerializeObject(await methodInvocation);
+                }
 			}
 
 			return null;


### PR DESCRIPTION
Whenever we were calling grains that returned complex object types we were failing to print the messages. This will parse all grain invocation results to Json and Orniscient will be able to print the result.