### PR TITLE
Removed unused package OrleansCodeGenerator and respective reference.

### DIFF
--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/Derivco.Orniscient.Proxy.csproj
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/Derivco.Orniscient.Proxy.csproj
@@ -61,9 +61,6 @@
     <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Orleans.Core.1.5.0\lib\net461\Orleans.dll</HintPath>
     </Reference>
-    <Reference Include="OrleansCodeGenerator, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Orleans.OrleansCodeGenerator.1.5.0\lib\net461\OrleansCodeGenerator.dll</HintPath>
-    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>

--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/packages.config
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/packages.config
@@ -8,7 +8,6 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
-  <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.Owin.Security" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
Orniscient.Proxy does not use or require the OrleansCodeGenerator package (which is used by Orleans for runtime code generation). Currently, this would cause issues for any users of Orniscient who desire to use build-time code generation in Orleans instead, as it would require them to import the run-time code generation package when they don't need it and may cause complications when used in combination with the build-time library.