### PR TITLE
Added used reference to OrleansCodeGenerator

### DIFF
--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/Derivco.Orniscient.Proxy.csproj
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/Derivco.Orniscient.Proxy.csproj
@@ -209,4 +209,11 @@
   -->
   <Target Name="AfterBuild">
   </Target>
+  <Import Project="..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets'))" />
+  </Target>
 </Project>

--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/packages.config
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.Owin.Security" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />

--- a/Derivco.Orniscient/TestGrains/TestGrains.csproj
+++ b/Derivco.Orniscient/TestGrains/TestGrains.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>TestGrains</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -135,9 +137,18 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Derivco.Orniscient/TestGrains/packages.config
+++ b/Derivco.Orniscient/TestGrains/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />

--- a/Derivco.Orniscient/TestHost/TestHost.csproj
+++ b/Derivco.Orniscient/TestHost/TestHost.csproj
@@ -64,9 +64,6 @@
     <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Orleans.Core.1.5.0\lib\net461\Orleans.dll</HintPath>
     </Reference>
-    <Reference Include="OrleansCodeGenerator, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Orleans.OrleansCodeGenerator.1.5.0\lib\net461\OrleansCodeGenerator.dll</HintPath>
-    </Reference>
     <Reference Include="OrleansCounterControl, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Orleans.CounterControl.1.5.0\lib\net461\OrleansCounterControl.exe</HintPath>
     </Reference>
@@ -223,9 +220,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets" Condition="Exists('..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets')" />
   <Import Project="..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets')" />
+  <Import Project="..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Derivco.Orniscient/TestHost/packages.config
+++ b/Derivco.Orniscient/TestHost/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.CounterControl" version="1.5.0" targetFramework="net461" />
-  <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.OrleansHost" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.OrleansProviders" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.OrleansRuntime" version="1.5.0" targetFramework="net461" />

--- a/Derivco.Orniscient/TestHost2/TestHost2.csproj
+++ b/Derivco.Orniscient/TestHost2/TestHost2.csproj
@@ -64,9 +64,6 @@
     <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Orleans.Core.1.5.0\lib\net461\Orleans.dll</HintPath>
     </Reference>
-    <Reference Include="OrleansCodeGenerator, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Orleans.OrleansCodeGenerator.1.5.0\lib\net461\OrleansCodeGenerator.dll</HintPath>
-    </Reference>
     <Reference Include="OrleansCounterControl, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Orleans.CounterControl.1.5.0\lib\net461\OrleansCounterControl.exe</HintPath>
     </Reference>
@@ -223,9 +220,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets" Condition="Exists('..\packages\Microsoft.Orleans.CounterControl.1.5.0\build\Microsoft.Orleans.CounterControl.targets')" />
   <Import Project="..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansHost.1.5.0\build\Microsoft.Orleans.OrleansHost.targets')" />
+  <Import Project="..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.5.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Derivco.Orniscient/TestHost2/packages.config
+++ b/Derivco.Orniscient/TestHost2/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.CounterControl" version="1.5.0" targetFramework="net461" />
-  <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.OrleansHost" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.OrleansProviders" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.Orleans.OrleansRuntime" version="1.5.0" targetFramework="net461" />


### PR DESCRIPTION
Added OrleansCodeGenerator.Build to all relevant projects - this means that the code is generated at Build-Time rather than at Runtime. Following this change, the project should now successfully connect to a Silo.