### PR TITLE
Merge of Fork to Upstream

### DIFF
--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/DashboardCollectorGrain.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/DashboardCollectorGrain.cs
@@ -101,7 +101,7 @@ namespace Derivco.Orniscient.Proxy.Grains
 
 		    var streamProvider = GetStreamProvider(StreamKeys.StreamProvider);
 
-		    _logger.Info($"About to send the changes to the dashboardInstanceGrains");
+		    _logger.Verbose("About to send the changes to the dashboardInstanceGrains");
 		    var stream = streamProvider.GetStream<DiffModel>(Guid.Empty, StreamKeys.OrniscientChanges);
 		    await stream.OnNextAsync(diffModel);
 		    return diffModel;

--- a/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/DashboardCollectorGrain.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Proxy/Grains/DashboardCollectorGrain.cs
@@ -164,7 +164,7 @@ namespace Derivco.Orniscient.Proxy.Grains
 
         private async Task<List<UpdateModel>> _GetAllFromCluster()
         {
-            _logger.Info("_GetAllFromCluster called");
+            _logger.Verbose("_GetAllFromCluster called");
             var detailedStats = await _managementGrain.GetDetailedGrainStatistics(_filteredTypes?.Select(p => p.FullName).ToArray()); ;
             if (detailedStats != null && detailedStats.Any())
             {

--- a/Derivco.Orniscient/Derivco.Orniscient.Viewer/Clients/GrainClientMultiton.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Viewer/Clients/GrainClientMultiton.cs
@@ -40,9 +40,9 @@ namespace Derivco.Orniscient.Viewer.Clients
             return _clients[key];
         }
 
-        public static string RegisterClient(string address, int port)
+        public static string RegisterClient(string address, int port, string guid = null)
         {
-            var grainClientKey = Guid.NewGuid().ToString();
+            var grainClientKey = string.IsNullOrWhiteSpace(guid) ? Guid.NewGuid().ToString() : guid;
             _semaphoreSlim.Wait();
             try
             {

--- a/Derivco.Orniscient/Derivco.Orniscient.Viewer/Controllers/DashboardController.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Viewer/Controllers/DashboardController.cs
@@ -30,9 +30,9 @@ namespace Derivco.Orniscient.Viewer.Controllers
             {
                 await CleanupConnection(connection);
 
-                if(!HttpContext.Request.Cookies.AllKeys.Contains("GrainSessionId"))
+                if(!HttpContext.Request.Cookies.AllKeys.Contains("GrainSessionId") || GrainClientMultiton.GetClient(GrainSessionId) == null)
                 {
-                    var grainSessionIdKey = GrainClientMultiton.RegisterClient(connection.Address, connection.Port);
+                    var grainSessionIdKey = GrainClientMultiton.RegisterClient(connection.Address, connection.Port, GrainSessionId);
                     HttpContext.Response.Cookies.Add(new HttpCookie("GrainSessionId", grainSessionIdKey));
                 }
 
@@ -62,7 +62,6 @@ namespace Derivco.Orniscient.Viewer.Controllers
                     if (gateway.Port != connection.Port)
                     {
                         await CleanupClient();
-                        RemoveCookie("GrainSessionId");
                     }
                 }
             }
@@ -77,7 +76,7 @@ namespace Derivco.Orniscient.Viewer.Controllers
 
         private async Task CleanupClient()
         {
-            await OrniscientObserver.Instance.UnregisterGrainClient(GrainSessionId);
+            await OrniscientObserver.Instance.UnregisterGrainClient(GrainSessionId);    
             GrainClientMultiton.RemoveClient(GrainSessionId);
         }
 

--- a/Derivco.Orniscient/Derivco.Orniscient.Viewer/Models/Connection/ConnectionInfo.cs
+++ b/Derivco.Orniscient/Derivco.Orniscient.Viewer/Models/Connection/ConnectionInfo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Web;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace Derivco.Orniscient.Viewer.Models.Connection
 {


### PR DESCRIPTION
Changed two output messages to verbose as they are called quite often.
Auto resolve hostname when doing cleanup connection as if host names are used they will not match directly as orleans connects via IP.
If dashboard is refreshed cookie is kept if request (url containing address and port) has changed and instead cleans up client and creates a new one to match that request.
Small refactoring.